### PR TITLE
Add support to use backing files for PV (ready)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,35 +9,66 @@ note:: The `lvm.conf(5)` is indirectly managed via LVM profiles.
 note:: See the full `Salt Formulas installation and usage instructions
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
-Available states
-================
+Available Meta states
+======================
 
 .. contents::
     :local:
 
 ``lvm``
 --------
-Meta-state to execute all LVM2 states listed below.
+Meta-state to run all states in sequence: 'install', 'profiles', 'files', 'pv', 'vg', and 'lv'.
 
-note:: Order 'install', 'profiles', 'pv', 'vg', and 'lv'.
+``lvm.profiles``
+--------------
+Meta-state to manage lvm profiles in sequence: 'remove', followed by 'create'.
+
+``lvm.files``
+-----------
+Meta-state to run loopback file device states in sequence: 'remove', followed by 'create'. Included by `lvm.pv` state.
+
+``lvm.pv``
+-----------
+Meta-state to run physical volume (PV) states in sequence: 'remove', 'change', 'resize', 'move', and finally 'create'.
+
+``lvm.vg``
+--------------
+Meta-state to run all volume group states in sequence: 'cfgbackup', 'import', 'remove', 'change' 'reduce', 'extend', 'split', 'merge', 'rename', 'create', 'export' & 'cfgrestore'.
+
+``lvm.lv``
+-------------
+Meta-state to run all logical volume states in sequence: Order 'remove', 'change', 'reduce', 'extend', 'rename', 'create', 'convert', and 'create' again.
+
+
+Available states
+================
+
+.. contents::
+    :local:
+
+``lvm.remove``
+------------
+Remove lvm2 software.
+
+``lvm.profiles.remove``
+----------------------
+Remove custom lvm profile(s)::
+
+  profiles:
+    remove:
+      - sillyprofile
 
 ``lvm.install``
 -----------
 Install lvm2 package.
 
-``config``
+``lvm.config (depreciated)``
 ----------
 Configure PVs, VGs and LVs using legacy pillar data (backwards compatibility only).
 
 ``lvm.remove``
 ------------
 Remove lvm2 software.
-
-``lvm.profiles``
---------------
-Meta-state to mange lvm profiles.
-
-note:: Order 'remove', then 'create'.
 
 ``lvm.profiles.remove``
 ----------------------
@@ -59,11 +90,42 @@ Create custom lvm profile(s)::
             thin_pool_autoextend_threshold: 70
             thin_pool_autoextend_percent: 20
 
-``lvm.pv``
------------
-Meta-state to execute all physical volume (PV) states.
 
-note:: Order 'remove', 'change', 'resize', 'move', and finally 'create'.
+``lvm.files.remove``
+------------------
+Remove LVM backing files from the file system
+
+``lvm.files.create``
+------------------
+LVM Loopback HOW-TO support. Creates backing files (in /tmp by defaults.yaml) and loopback devices according to pillars.
+
+```
+  lvm: 
+    files:
+      #loopbackdir: /tmp         #Where to create backing files? Default is /tmp anyway.
+      remove:
+        - /tmp/testfile1.img
+        - /tmp/testfile2.img
+      create:
+        truncate:                #Shrink or extend the size of each FILE to the specified size
+          testfile1.img:
+            options:
+              size: 100M
+        dd:                      #copy a file, converting and formatting according to the operands
+          testfile2.img:
+            options:
+              if: /dev/urandom
+              bs: 1024
+              count: 204800
+        losetup:                 #set up and control loop devices
+          testfile1.img:
+          testfile2.img:
+    pv:
+      create:
+        /dev/loop0:               #hopefully  /tmp/testfile1.img
+        /dev/loop1:               #hopefully  /tmp/testfile2.img
+
+```
 
 ``lvm.pv.remove``
 --------------
@@ -135,11 +197,8 @@ Initialize disk(s) or partition(s) for use by LVM::
         options:
           metadatacopies: 1
 
-``lvm.vg``
---------------
-Meta-state to execute all volume group states.
 
-note:: Order 'cfgbackup', 'import', 'remove', 'change' 'reduce', 'extend', 'split', 'merge', 'rename', 'create', 'export' & 'cfgrestore'.
+
 
 ``lvm.vg.cfgbackup``
 -------------------
@@ -289,11 +348,7 @@ Restore the metadata of VG(s) from text backup files produced by ``lvm.vg.cfgbac
           debug: True
 
 
-``lvm.lv``
--------------
-Meta-state to execute all logical volume states.
 
-note:: Order 'remove', 'change', 'reduce', 'extend', 'rename', 'create', 'convert', and 'create' again.
 
 ``lvm.lv.remove``
 ---------------

--- a/lvm/defaults.yaml
+++ b/lvm/defaults.yaml
@@ -6,6 +6,8 @@ lvm:
   group: root
   filemode: '0640'
   dir_mode: '0755'
+  files:
+    loopbackdir: /tmp
 
   config:
     dir:

--- a/lvm/files/create.sls
+++ b/lvm/files/create.sls
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "lvm/map.jinja" import lvm with context %}
+{% from "lvm/templates/macros.jinja" import getopts, getoperands with context %}
+
+{%- if "create" in lvm.files and lvm.files.create is mapping %}
+  {%- if "truncate" in lvm.files.create and lvm.files.create.truncate is mapping %}
+    {% for file, filedata in lvm.files.create.truncate.items() %}
+
+##Shrink or extend the size of each FILE to the specified size
+lvm file truncate {{ file }}:
+  cmd.run:
+    - cwd: {{ lvm.files.loopbackdir or '/tmp' }}
+    - name: truncate {{- getopts(filedata) }} {{ file }}
+    - unless: test -f {{ file }}
+
+    {%- endfor %}
+  {%- endif %}
+
+  {%- if "dd" in lvm.files.create and lvm.files.create.dd is mapping %}
+    {% for file, filedata in lvm.files.create.dd.items() %}
+
+##Copy a file, converting and formatting according to the operands
+lvm file dd {{ file }}:
+  cmd.run:
+    - cwd: {{ lvm.files.loopbackdir or '/tmp' }}
+    - name: dd {{- getoperands(filedata) }} of={{ file }}
+    - unless: test -f {{ file }}
+
+    {%- endfor %}
+  {%- endif %}
+
+  {%- if "losetup" in lvm.files.create and lvm.files.create.losetup is mapping %}
+    {% for file, filedata in lvm.files.create.losetup.items() %}
+
+lvm file losetup {{ file }} as loopback device:
+  cmd.run:
+    - cwd: {{ lvm.files.loopbackdir or '/tmp' }}
+    - name: losetup {{ getopts(filedata) or '--show --find' }}{{' '}}{{ file }}
+    - onlyif: test -f {{ file }}
+
+    {%- endfor %}
+  {%- endif %}
+
+{%- else %}
+
+lvm_files_create_nothing_to_do:
+  test.show_notification:
+    - text: |
+        No "files.create" pillar data supplied - nothing to do!
+
+{%- endif %}

--- a/lvm/files/init.sls
+++ b/lvm/files/init.sls
@@ -1,0 +1,5 @@
+## Automate tasks in logical sequence ...
+
+include:
+  - .remove
+  - .create

--- a/lvm/files/remove.sls
+++ b/lvm/files/remove.sls
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "lvm/map.jinja" import lvm with context %}
+
+  {%- if "remove" in lvm.files and lvm.files.remove is iterable and lvm.files.remove is not string %}
+    {% set loopdevs = salt['cmd.shell']('losetup -a | cut -d: -f1').split('\n') or [] %}
+    {%- for file in lvm.files.remove %}
+
+      {%- for loopdev in loopdevs %}
+         {%- if loopdev %}
+lvm file losetup delete {{ loopdev|lower }} if attached to {{ file }}:
+  cmd.run:
+    - name: losetup --detach {{ loopdev }}
+    - onlyif: losetup -a | grep {{ loopdev }} | grep {{ file }}
+         {%- endif %}
+      {% endfor %}
+
+lvm file remove {{ file }}:
+  file.absent:
+    - name: {{ file }}
+
+    {% endfor %}
+  {%- else %}
+
+lvm_files_remove_nothing_to_do:
+  test.show_notification:
+    - text: |
+        No "files.remove" pillar data supplied - nothing to do!
+
+  {%- endif %}

--- a/lvm/init.sls
+++ b/lvm/init.sls
@@ -7,6 +7,7 @@ include:
     - lvm.install
     - lvm.config
     - lvm.profiles
+    - lvm.files
     - lvm.pv
     - lvm.vg
     - lvm.lv

--- a/lvm/pv/create.sls
+++ b/lvm/pv/create.sls
@@ -4,7 +4,7 @@
 {% from "lvm/templates/macros.jinja" import getopts with context %}
 
 {%- if lvm.pv and "create" in lvm.pv and lvm.pv.create is mapping %}
-  {% for pv, pvdata in lvm.pv.create.items() %}
+  {% for pv, pvdata in lvm.pv.create.items() if pv not in ('create', 'delete',) %}
 
 lvm_pv_create_{{ pv }}:
   lvm.pv_present:

--- a/lvm/templates/macros.jinja
+++ b/lvm/templates/macros.jinja
@@ -4,9 +4,17 @@
        {%- if sls %}
     - {{ k }}: {{ v }}
        {%- else %}
-         {{- ' --' ~ k if v == True else '' if v == False else ' --' ~ k ~ ' ' ~ v  -}}
+         {{- ' --' ~ k if v == True else '' if v in ('none',) or not v else ' --' ~ k ~ ' ' ~ v  -}}
        {%- endif %}
       {%- endfor %}
+   {%- endif %}
+{%- endmacro %}
+
+{%- macro getoperands(outdict, sls=False) -%}
+  {%- if outdict and 'options' in outdict %}
+     {%- for k, v in outdict.options.items() %}
+         {{ ' ' ~ k if v == True else '' if v in ('none',) or not v else ' ' ~ k ~ '=' ~ v }}
+     {%- endfor %}
    {%- endif %}
 {%- endmacro %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -19,8 +19,42 @@ lvm:
         activation:
           thin_pool_autoextend_threshold: 70
           thin_pool_autoextend_percent: 20
+
+  files:
+    #loopbackdir: /tmp         #Where to create backing files? Default is /tmp anyway.
+    remove:
+      - /tmp/testfile1.img
+      - /tmp/testfile2.img
+    create:
+      truncate:                #Shrink or extend the size of each FILE to the specified size
+        testfile1.img:
+          options:
+            size: 100M
+      dd:                      #copy a file, converting and formatting according to the operands
+        testfile2.img:
+          options:
+            if: /dev/urandom
+            bs: 1024
+            count: 204800
+      losetup:                 #set up and control loop devices. todo: could be converted to 'list' instead.
+        testfile1.img:
+          options:
+            show: True         #This is default anyway
+            find: True         #This is default anyway
+        testfile2.img:         #So specifying options is unnecessary if you prefer.
+  pv:
+    create:
+      /dev/loop0:               #hopefully  /tmp/testfile1.img
+      /dev/loop1:               #hopefully  /tmp/testfile2.img
+
   pv:
     remove:
+      /tmp/loopback1
+        options:
+          verbose: True
+        loopback:
+          size: 10G
+          encryption: none
       /dev/sdb:
         options:
           verbose: True


### PR DESCRIPTION
This PR adds support for using file as backing devices for LVM PVs.  Its WIP until #3 and #4 are merged then it can be reviewed.  The PR supports following `losetup(8)' workflow.

>     The following commands can be used as an example of using the loop device.
>     # dd if=/dev/zero of=/file bs=1k count=100
>     # losetup -e des /dev/loop0 /file
>     Password:
>     Init (up to 16 hex digits):
>     # mkfs -t ext2 /dev/loop0 100
>     # mount -t ext2 /dev/loop0 /mnt
>      ....
>     # umount /dev/loop0
>     # losetup -d /dev/loop0

Note: some technical sources use `truncate` (instead of `dd`) so both commands are supported.

**Example Pillars::**
```
lvm:
  files:
    loopbackdir: /tmp         #Where to create backing files? Default is /tmp anyway.
    remove:
      - /tmp/testfile1.img
      - /tmp/testfile2.img
    create:
      truncate:                #Shrink or extend the size of each FILE to the specified size
        /tmp/testfile1.img
          options:
            size: 100M
      dd:                      #copy a file, converting and formatting according to the operands
        /tmp/testfile2.img
          options:
            if: /dev/urandom
            bs: 1024
            count: 204800
      losetup:                 #set up and control loop devices
        /tmp/testfile1.img:
          options:
            show: True
            find: True
         /tmp/testfile2.img:
  pv:
    create:
      /dev/loop0:               #hopefully  /tmp/testfile1.img
      /dev/loop1:                #hopefully  /tmp/testfile2.img
        
```
Existing functionality is not impacted.  

