### PR TITLE
Don't use /tmp for tempdir

### DIFF
--- a/lvm/defaults.yaml
+++ b/lvm/defaults.yaml
@@ -9,7 +9,7 @@ lvm:
   filemode: '0640'
   dir_mode: '0755'
   files:
-    loopbackdir: /tmp
+    loopbackdir: /tmp/loopdevs
 
   config:
     dir:

--- a/pillar.example
+++ b/pillar.example
@@ -21,35 +21,35 @@ lvm:
           thin_pool_autoextend_percent: 20
 
   files:
-    #loopbackdir: /tmp         #Where to create backing files? Default is /tmp anyway.
+    #loopbackdir: /tmp/loopdevs   #Where to create backing files?
     remove:
-      - /tmp/testfile1.img
-      - /tmp/testfile2.img
+      - /tmp/loopdevs/testfile1.img
+      - /tmp/loopdevs/testfile2.img
     create:
-      truncate:                #Shrink or extend the size of each FILE to the specified size
+      truncate:   #Shrink or extend the size of each FILE to the specified size
         testfile1.img:
           options:
             size: 100M
-      dd:                      #copy a file, converting and formatting according to the operands
+      dd:    #copy a file, converting and formatting according to the operands
         testfile2.img:
           options:
             if: /dev/urandom
             bs: 1024
             count: 204800
-      losetup:                 #set up and control loop devices. todo: could be converted to 'list' instead.
+      losetup:  #setup loop devices. todo: could be 'list' instead.
         testfile1.img:
           options:
-            show: True         #This is default anyway
-            find: True         #This is default anyway
-        testfile2.img:         #So specifying options is unnecessary if you prefer.
+            show: True      #This is default anyway
+            find: True      #This is default anyway
+        testfile2.img:      #So specifying options is unnecessary if you prefer.
   pv:
     create:
-      /dev/loop0:               #hopefully  /tmp/testfile1.img
-      /dev/loop1:               #hopefully  /tmp/testfile2.img
+      /dev/loop0:           #hopefully  /tmp/loopdevs/testfile1.img
+      /dev/loop1:           #hopefully  /tmp/loopdevs/testfile2.img
 
   pv:
     remove:
-      /tmp/loopback1
+      /tmp/loopdevs/loopback1
         options:
           verbose: True
         loopback:


### PR DESCRIPTION
Don't use /tmp as tempdir by default. Ensure the tempdir exists with 0755 permissions.