### PR TITLE
Fix three minor issues

### DIFF
--- a/lvm/init.sls
+++ b/lvm/init.sls
@@ -5,7 +5,6 @@
 
 include:
     - lvm.install
-    - lvm.config
     - lvm.profiles
     - lvm.files
     - lvm.pv

--- a/lvm/lv/change.sls
+++ b/lvm/lv/change.sls
@@ -9,7 +9,7 @@
 lvm_lv_change_{{ lv }}:
   cmd.run:
     - name: lvchange {{ getopts(lvdata) }} {{ lv }}
-    - onlyif: lvdisplay {{ lv }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/lv/convert.sls
+++ b/lvm/lv/convert.sls
@@ -10,7 +10,7 @@
 lvm_lv_convert_{{ lv }}:
   cmd.run:
     - name: lvconvert --yes {{ getopts(lvdata) }} {{ lv }} {{ getlist(lvdata['devices']) if 'devices' in lvdata else '' }}
-    - onlyif: lvdisplay {{ lv }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/lv/create.sls
+++ b/lvm/lv/create.sls
@@ -13,8 +13,8 @@
 lvm_lv_create_{{ lv }}:
   cmd.run:
     - name: lvcreate --yes {{- getopts(lvdata) }} --name {{ lvdata['vgname'] }}/{{ lv }} --snapshot {{ lvdata['sourcelv'] }} {{- getlist(lvdata['devices']) if 'devices' in lvdata else '' }}
-    - unless: lvdisplay {{ lvdata['vgname'] }}/{{ lv }}
-    - onlyif: lvdisplay {{ lvdata['vgname'] }}/{{ lvdata['sourcelv'] }}
+    - unless: lvdisplay {{ lvdata['vgname'] }}/{{ lv }} 2>/dev/null
+    - onlyif: lvdisplay {{ lvdata['vgname'] }}/{{ lvdata['sourcelv'] }} 2>/dev/null
     #force??
 
     {%- else %}
@@ -32,7 +32,7 @@ lvm_lv_create_{{ lv }}:
     {{ getopts(lvdata, True) }}
 
     {%- endif %}
-    - unless: lvdisplay {{ lv }} || lvdisplay {{ lvdata['vgname'] }}/{{ lv }}
+    - unless: lvdisplay {{ lv }} 2>/dev/null || lvdisplay {{ lvdata['vgname'] }}/{{ lv }} 2>/dev/null
   {%- endfor %}
 {%- else %}
 

--- a/lvm/lv/extend.sls
+++ b/lvm/lv/extend.sls
@@ -10,7 +10,7 @@
 lvm_lv_extend_{{ lv }}:
   cmd.run:
     - name: lvextend {{ getopts(lvdata) }} {{ lv }} {{ getlist(lvdata['devices']) }}
-    - onlyif: lvdisplay {{ lv }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/lv/reduce.sls
+++ b/lvm/lv/reduce.sls
@@ -9,7 +9,7 @@
 lvm_lv_reduce_{{ lv }}:
   cmd.run:
     - name: lvreduce {{ getopts(lvdata) }} {{ lv }}
-    - onlyif: lvdisplay {{ lv }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/lv/remove.sls
+++ b/lvm/lv/remove.sls
@@ -9,7 +9,7 @@
 lvm_lv_remove_{{ lv }}:
   cmd.run:
     - name: lvremove --yes {{ getopts(lvdata) }} {{ lv }}
-    - onlyif: lvdisplay {{ lv }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/lv/rename.sls
+++ b/lvm/lv/rename.sls
@@ -9,8 +9,8 @@
 lvm_lv_rename_{{ lv }}:
   cmd.run:
     - name: lvrename {{ getopts(lvdata) }} {{ lv }} {{ lvdata['vgname'] }}/{{ lvdata['newname'] }}
-    - onlyif: lvdisplay {{ lv }}
-    - unless: lvdisplay {{ lvdata['vgname'] }}/{{ lvdata['newname'] }}
+    - onlyif: lvdisplay {{ lv }} 2>/dev/null
+    - unless: lvdisplay {{ lvdata['vgname'] }}/{{ lvdata['newname'] }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/pv/change.sls
+++ b/lvm/pv/change.sls
@@ -10,8 +10,8 @@ lvm_pv_change_{{ pv }}:
   cmd.run:
     - name: pvchange --yes {{ getopts(pvdata) }} {{ pv }}
     - onlyif:
-      - pvdisplay {{ pv }}
-      - pvdisplay {{ pv }} | grep -i 'vg name[a-zA-Z1-9].*' 2>/dev/null
+      - pvdisplay {{ pv }} 2>/dev/null
+      - pvdisplay {{ pv }} 2>/dev/null | grep -i 'vg name[a-zA-Z1-9].*' 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/pv/create.sls
+++ b/lvm/pv/create.sls
@@ -9,7 +9,7 @@
 lvm_pv_create_{{ pv }}:
   lvm.pv_present:
     - name: {{ pv }}
-    - unless: pvdisplay {{ pv }}
+    - unless: pvdisplay {{ pv }} 2>/dev/null
     {{ getopts(pvdata, True) }}
 
   {%- endfor %}

--- a/lvm/pv/move.sls
+++ b/lvm/pv/move.sls
@@ -10,9 +10,9 @@ lvm_pv_move_{{ pv }}:
   cmd.run:
     - name: pvmove --yes {{ getopts(pvdata) }} {{ pv }} {{ pvdata['dest'] }}
     - onlyif:
-      - pvdisplay {{ pv }}
-      - pvdisplay {{ pvdata['dest'] }}
-      - pvdisplay {{ pvdata['dest'] }} | grep -i 'vg name[a-zA-Z1-9].*' 2>/dev/null
+      - pvdisplay {{ pv }} 2>/dev/null
+      - pvdisplay {{ pvdata['dest'] }} 2>/dev/null
+      - pvdisplay {{ pvdata['dest'] }} 2>/dev/null | grep -i 'vg name[a-zA-Z1-9].*' 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/pv/remove.sls
+++ b/lvm/pv/remove.sls
@@ -9,7 +9,7 @@
 lvm_pv_remove_{{ pv }}:
   cmd.run:
     - name: pvremove --yes {{ getopts(pvdata) }} {{ pv }}
-    - onlyif: pvdisplay {{ pv }}
+    - onlyif: pvdisplay {{ pv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/pv/resize.sls
+++ b/lvm/pv/resize.sls
@@ -9,7 +9,7 @@
 lvm_pv_resize_{{ pv }}:
   cmd.run:
     - name: pvresize --yes {{ getopts(pvdata) }} {{ pv }}
-    - onlyif: pvdisplay {{ pv }}
+    - onlyif: pvdisplay {{ pv }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/remove.sls
+++ b/lvm/remove.sls
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+## Automate tasks in logical sequence ...
+
+include:
+    - lvm.lv.remove
+    - lvm.vg.remove
+    - lvm.pv.remove
+    - lvm.profiles.remove
+    - lvm.files.remove

--- a/lvm/vg/cfgbackup.sls
+++ b/lvm/vg/cfgbackup.sls
@@ -18,7 +18,7 @@ lvm_vg_cfgbackup_dir:
 lvm_vg_cfgbackup_{{ vg }}:
   cmd.run:
     - name: vgcfgbackup -f {{ lvm.config.dir.backups }}/{{ vgdata['file'] }} {{ getopts(vgdata) }} {{ vg }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
     - require:
       - file: lvm_vg_cfgbackup_dir
 

--- a/lvm/vg/cfgrestore.sls
+++ b/lvm/vg/cfgrestore.sls
@@ -19,7 +19,7 @@ lvm_vg_cfgrestore_{{ vg }}:
   cmd.run:
     - name: vgcfgrestore -f {{ lvm.config.dir.restores }}/{{ vgdata['file'] }} {{ getopts(vgdata) }} {{ vg }}
     - onlyif:
-      - vgdisplay {{ vg }}
+      - vgdisplay {{ vg }} 2>/dev/null
       - test -f {{ lvm.config.dir.restores }}/{{ vgdata['file'] }}
     - require:
       - file: lvm_vg_cfgrestore_dir

--- a/lvm/vg/change.sls
+++ b/lvm/vg/change.sls
@@ -9,7 +9,7 @@
 lvm_vg_change_{{ vg }}:
   cmd.run:
     - name: vgchange {{ getopts(vgdata) }} {{ vg }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/create.sls
+++ b/lvm/vg/create.sls
@@ -11,10 +11,10 @@ lvm_vg_create_{{ vg }}:
     - name: {{ vg }}
     - devices: {{ vgdata['devices'] }}
     - unless:
-      - vgdisplay {{ vg }}
+      - vgdisplay {{ vg }} 2>/dev/null
       {%- for dev in vgdata['devices'] %}
         {# salt ignores True from multiple unless conditions? bug. #}
-      - pvdisplay {{ dev }} | grep -i 'vg name.*[a-zA-Z1-9].*' 2>/dev/null
+      - pvdisplay {{ dev }} 2>/dev/null | grep -i 'vg name.*[a-zA-Z1-9].*' 2>/dev/null
       {%- endfor %}
     {{ getopts(vgdata, True) }}
 

--- a/lvm/vg/export.sls
+++ b/lvm/vg/export.sls
@@ -9,7 +9,7 @@
 lvm_vg_export_{{ vg }}:
   cmd.run:
     - name: vgexport {{ getopts(vgdata) }} {{ vg }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/extend.sls
+++ b/lvm/vg/extend.sls
@@ -10,7 +10,7 @@
 lvm_vg_extend_{{ vg }}:
   cmd.run:
     - name: vgextend {{ getopts(vgdata) }} {{ vg }} {{ getlist(vgdata['devices']) }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/import.sls
+++ b/lvm/vg/import.sls
@@ -9,7 +9,7 @@
 lvm_vg_import_{{ vg }}:
   cmd.run:
     - name: vgimport {{ getopts(vgdata) }} {{ vg }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/merge.sls
+++ b/lvm/vg/merge.sls
@@ -9,7 +9,7 @@
 lvm_vg_merge_{{ vg }}:
   cmd.run:
     - name: vgmerge {{ getopts(vgdata) }} {{ vg }} {{ vgdata['withvg'] }}
-    - onlyif: vgdisplay {{ vg }} && vgdisplay {{ vgdata['withvg'] }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null && vgdisplay {{ vgdata['withvg'] }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/reduce.sls
+++ b/lvm/vg/reduce.sls
@@ -10,7 +10,7 @@
 lvm_vg_reduce_{{ vg }}:
   cmd.run:
     - name: vgreduce {{ getopts(vgdata) }} {{ vg }} {{ getlist(vgdata['devices']) }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/remove.sls
+++ b/lvm/vg/remove.sls
@@ -9,7 +9,7 @@
 lvm_vg_remove_{{ vg }}:
   cmd.run:
     - name: vgremove --yes {{ getopts(vgdata) }} {{ vg }}
-    - onlyif: vgdisplay {{ vg }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/rename.sls
+++ b/lvm/vg/rename.sls
@@ -9,8 +9,8 @@
 lvm_vg_rename_{{ vg }}:
   cmd.run:
     - name: vgrename {{ getopts(vgdata) }} {{ vg }} {{ vgdata['newname'] }}
-    - onlyif: vgdisplay {{ vg }}
-    - unless: vgdisplay {{ vgdata['newname'] }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
+    - unless: vgdisplay {{ vgdata['newname'] }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}

--- a/lvm/vg/split.sls
+++ b/lvm/vg/split.sls
@@ -10,8 +10,8 @@
 lvm_vg_split_{{ vg }}:
   cmd.run:
     - name: vgsplit {{ getopts(vgdata) }} {{ vg }} {{ vgdata['newvg'] }} {{ getlist(vgdata['devices']) }}
-    - onlyif: vgdisplay {{ vg }}
-    - unless: vgdisplay {{ vgdata['newvg'] }}
+    - onlyif: vgdisplay {{ vg }} 2>/dev/null
+    - unless: vgdisplay {{ vgdata['newvg'] }} 2>/dev/null
 
   {%- endfor %}
 {%- else %}


### PR DESCRIPTION
This PR has three updates.

1/ Hide STDERR from unless/onlyif conditionals.
```
[ERROR   ] Command '[u'pvdisplay', u'-c', u'/dev/loop0']' failed with return code: 5
[ERROR   ] stderr:   Failed to find physical volume "/dev/loop0".
[ERROR   ] retcode: 5
[ERROR   ] Command '[u'pvdisplay', u'-c', u'/dev/loop0']' failed with return code: 5
[ERROR   ] stderr:   Failed to find physical volume "/dev/loop0".
[ERROR   ] retcode: 5
```

2/ Create missing remove state documented in README.
```
    No matching sls found for 'lvm.remove' in env 'base'
```

3/ Remove config.sls from init.sls - its only for legacy pillar data.
```
[CRITICAL] Rendering SLS 'base:lvm.config' failed: Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'devices'
```