### PR TITLE
Ensure lvm2 gets installed - fallback else

### DIFF
--- a/lvm/install.sls
+++ b/lvm/install.sls
@@ -4,10 +4,14 @@
 {% from "lvm/map.jinja" import lvm_settings with context %}
 {% from "lvm/map.jinja" import lvm with context %}
 
-lvm packages:
+lvm packages installed:
   pkg.installed:
-      {% if "pkgs" in lvm %}
+      {%- if "pkgs" in lvm %}
     - names: {{ lvm.pkgs }}
-      {% else %}
-    - name: {{ lvm.pkg if "pkg" in lvm else lvm_settings.pkg }}
+      {%- elif "pkg" in lvm %}
+    - name: {{ lvm.pkg }}
+      {%- elif "pkg" in lvm_settings %}
+    - name: {{ lvm_settings.pkg }}
+      {%- else %}
+    - name: lvm2
       {% endif %}


### PR DESCRIPTION
On CentOS (no pillars) the lvm2 package never got installed.  This PR ensures formula adds fallback `else` to explicitly name the package.