### PR TITLE
fix(jinja): avoid non-backward compatible yaml rendering

### DIFF
--- a/lvm/config.sls
+++ b/lvm/config.sls
@@ -30,7 +30,7 @@ lvm.pv.create_{{ pv_options.device|default(pv) }}:
 lvm.vg.create_{{ vg_options.name|default(vg) }}:
     lvm.vg_present:
         - name: {{ vg_options.name|default(vg) }}
-        - devices: {{ vg_options.devices }}
+        - devices: {{ vg_options.devices|json }}
     {% if 'options' in vg_options and vg_options.options %}
     {% for opt,value in vg_options.options.items() %}
         - {{ opt }}: {{ value }} 

--- a/lvm/install.sls
+++ b/lvm/install.sls
@@ -7,7 +7,7 @@
 lvm packages installed:
   pkg.installed:
       {%- if "pkgs" in lvm %}
-    - names: {{ lvm.pkgs }}
+    - names: {{ lvm.pkgs|json }}
       {%- elif "pkg" in lvm %}
     - name: {{ lvm.pkg }}
       {%- elif "pkg" in lvm_settings %}

--- a/lvm/lv/create.sls
+++ b/lvm/lv/create.sls
@@ -23,7 +23,7 @@ lvm_lv_create_{{ lv }}:
 ## load kernel module if needed ##
 lvm_lv_create_{{ lv }}_kernel_modules:
   kmod.present:
-    - names: {{ lvm.kmodules  }}
+    - names: {{ lvm.kmodules|json  }}
     - onlyif: {{ 'thinvolume' in lvdata or 'thinpool' in lvdata }}
 
        {%- endif %}

--- a/lvm/vg/create.sls
+++ b/lvm/vg/create.sls
@@ -9,7 +9,7 @@
 lvm_vg_create_{{ vg }}:
   lvm.vg_present:
     - name: {{ vg }}
-    - devices: {{ vgdata['devices'] }}
+    - devices: {{ vgdata['devices']|json }}
     - unless:
       - vgdisplay {{ vg }} 2>/dev/null
       {%- for dev in vgdata['devices'] %}


### PR DESCRIPTION
Make formula compatible with salt 2019.2
```
ID: lvm packages installed
    Function: pkg.installed
        Name: u'lvm2'
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:

              errors:
                  - Running scope as unit: run-r7f6ca1091b2e4917b1973ef8df4ece07.scope
                    E: Unable to locate package u'lvm2'
     Started: 15:38:45.062402
    Duration: 2609.399 ms
     Changes:
----------
          ID: lvm packages installed
    Function: pkg.installed
        Name: u'cryptsetup'
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:

              errors:
                  - Running scope as unit: run-rd014f96d38ac48299d5431c57baa8d80.scope
                    E: Unable to locate package u'cryptsetup'
     Started: 15:38:47.672018
    Duration: 515.26 ms
     Changes:

```