### PR TITLE
refactor(map.jinja): use config.get

### DIFF
--- a/lvm/map.jinja
+++ b/lvm/map.jinja
@@ -7,7 +7,7 @@
     defaults,
     merge=salt['grains.filter_by'](
         osfamilymap,
-        merge=salt['pillar.get']('lvm', {}),
+        merge=salt['config.get']('lvm', {}),
     ),
     base='lvm',
 ) %}
@@ -16,5 +16,5 @@
 {% set os_family_map = salt['grains.filter_by']({
         'RedHat': { 'pkg': 'lvm2', },
         'Debian': { 'pkg': 'lvm2', },
-  }, merge=salt['pillar.get']('lvm:lookup')) %}
-{% set lvm_settings = salt['pillar.get']( 'lvm', default=os_family_map, merge=True) %}
+  }, merge=salt['config.get']('lvm:lookup')) %}
+{% set lvm_settings = salt['config.get']( 'lvm', default=os_family_map, merge=True) %}


### PR DESCRIPTION
This PR replaces `ERROR` with `WARNING`.

Saw these on FreeBSD. 

Using `pillar.get`
```
[ERROR   ] pillar.get: Default (None) is of type 'NoneType', must be a dict or list to merge. Merge will be skipped.
[ERROR   ] pillar.get: Default (None) is of type 'NoneType', must be a dict or list to merge. Merge will be skipped.
[ERROR   ] pillar.get: Default (None) is of type 'NoneType', must be a dict or list to merge. Merge will be skipped.
[ERROR   ] pillar.get: Default (None) is of type 'NoneType', must be a dict or list to merge. Merge will be skipped.
```

Using `config.get`
```
[WARNING ] Unsupported merge strategy 'True'. Falling back to 'recurse'.
[WARNING ] Unsupported merge strategy 'True'. Falling back to 'recurse'.
[WARNING ] Unsupported merge strategy 'True'. Falling back to 'recurse'.
[WARNING ] Unsupported merge strategy 'True'. Falling back to 'recurse'.
```